### PR TITLE
Remove "show more" link on the resource page

### DIFF
--- a/ckanext/odp_theme/templates/package/resource_read.html
+++ b/ckanext/odp_theme/templates/package/resource_read.html
@@ -1,0 +1,36 @@
+{% ckan_extends %}
+{% block resource_additional_information %}
+  {% if res %}
+    <section class="module">
+      <div class="module-content">
+        <h2>{{ _('Additional Information') }}</h2>
+        <table class="table table-striped table-bordered table-condensed">
+          <thead>
+            <tr>
+              <th scope="col">{{ _('Field') }}</th>
+              <th scope="col">{{ _('Value') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">{{ _('Last updated') }}</th>
+              <td>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{{ _('Created') }}</th>
+              <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{{ _('Format') }}</th>
+              <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">{{ _('License') }}</th>
+              <td>{% snippet "snippets/license.html", pkg_dict=pkg, text_only=True %}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Closes #25 

Code copied from ckan default template for resource_read.html.
On line 7 I removed the `data-module="table-toggle-more"` property. Right above `</tbody>` on line 31 I removed a for loop which created rows of additional information.
