### PR TITLE
Remove sidebar from Organizations and Topics page

### DIFF
--- a/ckanext/odp_theme/templates/group/index.html
+++ b/ckanext/odp_theme/templates/group/index.html
@@ -34,3 +34,5 @@
     {{ c.page.pager() }}
   {% endblock %}
 {% endblock %}
+
+{% block secondary %}{% endblock %}

--- a/ckanext/odp_theme/templates/organization/index.html
+++ b/ckanext/odp_theme/templates/organization/index.html
@@ -1,0 +1,2 @@
+{% ckan_extends %}
+{% block secondary %}{% endblock %}

--- a/ckanext/odp_theme/templates/page.html
+++ b/ckanext/odp_theme/templates/page.html
@@ -1,0 +1,42 @@
+{% ckan_extends %}
+{% block primary %}
+<div{% if self.secondary()|trim != '' %} class="primary"{% endif %}>
+    {#
+    The primary_content block can be used to add content to the page.
+    This is the main block that is likely to be used within a template.
+
+    Example:
+
+      {% block primary_content %}
+        <h1>My page content</h1>
+        <p>Some content for the page</p>
+      {% endblock %}
+    #}
+    {% block primary_content %}
+      <article class="module">
+        {% block page_header %}
+          <header class="module-content page-header">
+            {% if self.content_action() | trim %}
+              <div class="content_action">
+                {% block content_action %}{% endblock %}
+              </div>
+            {% endif %}
+            <ul class="nav nav-tabs">
+              {% block content_primary_nav %}{% endblock %}
+            </ul>
+          </header>
+        {% endblock %}
+        <div class="module-content">
+          {% if self.page_primary_action() | trim %}
+            <div class="page_primary_action">
+              {% block page_primary_action %}{% endblock %}
+            </div>
+          {% endif %}
+          {% block primary_content_inner %}
+          {% endblock %}
+        </div>
+      </article>
+    {% endblock %}
+  </div>
+{% endblock %}
+


### PR DESCRIPTION
In page.html, I've just added an if clause around `class="primary"` on line 3.

The padding on the right isn't quite correct. @jfrankl, perhaps this is something you are able to look at?

![margins](https://cloud.githubusercontent.com/assets/539905/6133463/ff23b086-b127-11e4-8b8c-764059243f56.png)
