### PR TITLE
Fix eternal loop

### DIFF
--- a/ckanext/odp_theme/controller.py
+++ b/ckanext/odp_theme/controller.py
@@ -1,7 +1,6 @@
 
 import datetime
 
-import ckan.plugins as p
 import ckan.model as model
 from ckan.plugins import toolkit as tk
 from ckan.common import c
@@ -9,7 +8,7 @@ from ckan.common import c
 from feedback_model import UnpublishedFeedback
 
 
-class UnpublishedReportController(p.toolkit.BaseController):
+class UnpublishedReportController(tk.BaseController):
     controller = 'ckanext.odp_theme.controller:UnpublishedReportController'
 
     def _is_unpublished(self, pkg):
@@ -41,7 +40,7 @@ class UnpublishedReportController(p.toolkit.BaseController):
         return tk.render('feedback/org.html')
 
 
-class UnpublishedFeedbackController(p.toolkit.BaseController):
+class UnpublishedFeedbackController(tk.BaseController):
     controller = 'ckanext.odp_theme.controller:UnpublishedFeedbackController'
 
     def view_feedback(self, id):

--- a/ckanext/odp_theme/plugin.py
+++ b/ckanext/odp_theme/plugin.py
@@ -13,21 +13,13 @@ from ckan.lib.activity_streams import \
 
 from feedback_model import init_db, UnpublishedFeedback
 
+
 def most_recent_datasets(num=3):
     """Return a list of recent datasets."""
-
-    # the current_package_list_with_resources action returns private resources
-    # which need to be filtered
-
-    datasets = []
-    i = 0
-    while len(datasets) < num:
-        datasets += filter(lambda ds: not ds['private'],
-                           tk.get_action('current_package_list_with_resources')({},
-                                         {'limit': num, 'offset': i * num}))
-        i += 1
-
-    return datasets[:num]
+    datasets = tk.get_action('package_search')({}, {'sort': 'metadata_modified desc',
+                                                    'fq': 'private:false',
+                                                    'rows': num})
+    return datasets.get('results', [])
 
 
 def apps(featured_only=True):


### PR DESCRIPTION
`most_recent_datasets` was trying to fill its quota without running an overlarge query by getting the latest datasets a few at a time, filtering out the private ones, and looping until the desired number were found. But if there are no datasets, as on a fresh provision, that never happens and the loop never terminates.

This changes it to use the `package_search` action, which supports filtering and limiting directly.

This should fix the "pegs the CPU and never returns a page" issue happening with https://github.com/azavea/opendataphilly-ckan/pull/54