### PR TITLE
Generate datastore API url from ckan url in config

### DIFF
--- a/ckanext/odp_theme/plugin.py
+++ b/ckanext/odp_theme/plugin.py
@@ -2,6 +2,7 @@
 from collections import OrderedDict
 
 import pylons
+from pylons import config
 
 from jinja2 import Undefined
 
@@ -59,6 +60,10 @@ def feedback_for_pkg(pkgid):
     """Return all feedback for a dataset"""
 
     return UnpublishedFeedback.get_for_package(pkgid).all()
+
+
+def ckan_site_url():
+    return config.get('ckan.site_url', '').rstrip('/')
 
 
 # monkeypatch activity streams
@@ -172,7 +177,8 @@ class ODPThemePlugin(ODPSearchPlugin):
                 'odp_theme_apps': apps,
                 'unpublished_count': UnpublishedFeedback.count_for_package,
                 'user_feedback': user_feedback,
-                'feedback_for_pkg': feedback_for_pkg}
+                'feedback_for_pkg': feedback_for_pkg,
+                'ckan_site_url': ckan_site_url}
 
     def before_map(self, map):
         return map

--- a/ckanext/odp_theme/templates/ajax_snippets/api_info.html
+++ b/ckanext/odp_theme/templates/ajax_snippets/api_info.html
@@ -1,0 +1,137 @@
+{#
+Displays information about accessing a resource via the API.
+
+datastore_root_url - The root API url.
+resource_id - The resource id
+embedded - If true will not include the "modal" classes on the snippet.
+
+Example
+
+    {% snippet 'ajax_snippets/api_info.html', datastore_root_url=datastore_root_url, resource_id=resource_id, embedded=true %}
+
+#}
+{% set datastore_root_url = h.ckan_site_url() + '/api/action' %}
+{% set sql_example_url = datastore_root_url + '/datastore_search_sql?sql=SELECT * from "' + resource_id + '" WHERE title LIKE \'jones\'' %}
+
+<div{% if not embedded %} class="modal"{% endif %}>
+  <div class="modal-header">
+    <h3>
+      {{ _('CKAN Data API') }}
+    </h3>
+  </div>
+  <div{% if not embedded %} class="modal-body"{% endif %}>
+    <p><strong>{{ _('Access resource data via a web API with powerful query support') }}</strong>.
+
+    {% set api_url = 'http://docs.ckan.org/en/{0}/datastore.html'.format(g.ckan_doc_version) %}
+    {% trans %}
+    Further information in the <a
+      href="{{ api_url }}" target="_blank">main
+      CKAN Data API and DataStore documentation</a>.</p>
+    {% endtrans %}
+    <div class="accordion" id="accordion2">
+    <div class="accordion-group">
+      <div class="accordion-heading">
+
+        <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-endpoints">{{ _('Endpoints') }} &raquo;</a>
+      </div>
+      <div id="collapse-endpoints" class="in accordion-body collapse">
+        <div class="accordion-inner">
+          <p>{{ _('The Data API can be accessed via the following actions of the CKAN action API.') }}</p>
+          <table class="table-condensed table-striped table-bordered">
+            <thead></thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Create') }}</th>
+                <td><code>{{ datastore_root_url }}/datastore_create</code></td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Update / Insert') }}</th>
+                <td><code>{{ datastore_root_url }}/datastore_upsert</code></td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Query') }}</th>
+                <td><code>{{ datastore_root_url }}/datastore_search</code></td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Query (via SQL)') }}</th>
+                <td><code>{{ datastore_root_url }}/datastore_search_sql</code></td>
+              </tr>
+
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion-group">
+      <div class="accordion-heading">
+        <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-querying">{{ _('Querying') }} &raquo;</a>
+      </div>
+      <div id="collapse-querying" class="collapse accordion-body in">
+        <div class="accordion-inner">
+          <strong>{{ _('Query example (first 5 results)') }}</strong>
+          <p>
+          <code><a href="{{ datastore_root_url }}/datastore_search?resource_id={{resource_id}}&limit=5" target="_blank">{{ datastore_root_url }}/datastore_search?resource_id={{resource_id}}&limit=5</a></code>
+          </p>
+
+          <strong>{{ _('Query example (results containing \'jones\')') }}</strong>
+          <p>
+          <code><a href="{{ datastore_root_url }}/datastore_search?resource_id={{resource_id}}&q=jones"
+              target="_blank">{{ datastore_root_url }}/datastore_search?resource_id={{resource_id}}&q=jones</a></code>
+          </p>
+
+          <strong>{{ _('Query example (via SQL statement)') }}</strong>
+          <p>
+          <code><a href="{{sql_example_url}}"
+              target="_blank">{{sql_example_url}}</a></code>
+          </p>
+
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion-group">
+      <div class="accordion-heading">
+       <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-javascript">{{ _('Example: Javascript') }} &raquo;</a>
+      </div>
+      <div id="collapse-javascript" class="accordion-body collapse">
+        <div class="accordion-inner">
+          <p>{{ _('A simple ajax (JSONP) request to the data API using jQuery.') }}</p>
+          <pre>
+  var data = {
+    resource_id: '{{resource_id}}', // the resource id
+    limit: 5, // get 5 results
+    q: 'jones' // query for 'jones'
+  };
+  $.ajax({
+    url: '{{ datastore_root_url }}/datastore_search',
+    data: data,
+    dataType: 'jsonp',
+    success: function(data) {
+      alert('Total results found: ' + data.result.total)
+    }
+  });</pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="accordion-group">
+      <div class="accordion-heading">
+        <a class="accordion-toggle" data-toggle="collapse" data-parent="accordion2" href="#collapse-python">{{ _('Example: Python') }} &raquo;</a>
+      </div>
+      <div id="collapse-python" class="accordion-body collapse">
+        <div class="accordion-inner">
+          <pre>
+import urllib
+url = '{{ datastore_root_url }}/datastore_search?limit=5&amp;q=title:jones'
+fileobj = urllib.urlopen(url)
+print fileobj.read()
+</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+</div>


### PR DESCRIPTION
## Demo

![image](https://user-images.githubusercontent.com/539905/31354565-d27399e4-ad04-11e7-8346-ecd3d9a58689.png)

## Testing

* http://localhost:8025/api/1/util/snippet/api_info.html?resource_id=1234&datastore_root_url=not_used