### PR TITLE
Link to google group on dataset page

### DIFF
--- a/ckanext/odp_theme/public/css/sass/main.scss
+++ b/ckanext/odp_theme/public/css/sass/main.scss
@@ -442,7 +442,3 @@ label {
 .ckanext-datapreview > iframe {
   min-height: 500px;
 }
-
-.google-groups-link {
-  padding: 0 30px 30px;
-  margin-top: -45px;

--- a/ckanext/odp_theme/public/css/sass/main.scss
+++ b/ckanext/odp_theme/public/css/sass/main.scss
@@ -443,3 +443,6 @@ label {
   min-height: 500px;
 }
 
+.google-groups-link {
+  padding: 0 30px 30px;
+  margin-top: -45px;

--- a/ckanext/odp_theme/templates/package/read.html
+++ b/ckanext/odp_theme/templates/package/read.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+{% block primary_content_inner %}
+    {{ super() }}
+
+    <div>
+      <h3>{{ _('Discussion') }}</h3>
+      Trouble downloading or have questions about this dataset? Visit the <a href="https://groups.google.com/forum/#!forum/opendataphilly">OpenDataPhilly Discussion Group</a>.
+    </div>
+{% endblock %}

--- a/ckanext/odp_theme/templates/package/read_base.html
+++ b/ckanext/odp_theme/templates/package/read_base.html
@@ -5,12 +5,3 @@
   {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
   {# {{ h.build_nav_icon('related_list', _('Related'), id=pkg.name) }} #}
 {% endblock %}
-
-{% block primary_content %}
-    {{ super() }}
-
-    <div class="google-groups-link">
-      <h3>{{ _('Discussion') }}</h3>
-      Trouble downloading or have questions about this dataset? Visit the <a href="https://groups.google.com/forum/#!forum/opendataphilly">OpenDataPhilly Discussion Group</a>.
-    </div>
-{% endblock %}

--- a/ckanext/odp_theme/templates/package/read_base.html
+++ b/ckanext/odp_theme/templates/package/read_base.html
@@ -5,3 +5,12 @@
   {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
   {# {{ h.build_nav_icon('related_list', _('Related'), id=pkg.name) }} #}
 {% endblock %}
+
+{% block primary_content %}
+    {{ super() }}
+
+    <div class="google-groups-link">
+      <h3>{{ _('Discussion') }}</h3>
+      Trouble downloading or have questions about this dataset? Visit the <a href="https://groups.google.com/forum/#!forum/opendataphilly">OpenDataPhilly Discussion Group</a>.
+    </div>
+{% endblock %}


### PR DESCRIPTION
Copy was taken from the wording used on most city datasets, with the removal of the word "City".

![screenshot from 2018-09-07 14-32-28](https://user-images.githubusercontent.com/4432106/45237014-8a0c1700-b2ab-11e8-849a-857323879443.png)


Connects to azavea/urban-apps#162