### PR TITLE
Fix PDF previewer height

### DIFF
--- a/ckanext/odp_theme/public/css/sass/main.scss
+++ b/ckanext/odp_theme/public/css/sass/main.scss
@@ -436,3 +436,10 @@ label {
 .input-group-btn {
   padding-left: 1px;
 }
+
+// Fix PDF previewer height. See related:
+// https://github.com/derilinx/ckanext-pdfview/commit/36081910d5bc38dcfbe82ac596c34c3b3be36107
+.ckanext-datapreview > iframe {
+  min-height: 500px;
+}
+


### PR DESCRIPTION
Stop blank space from showing at the bottom of PDF previews by making the `min-height` of the parent `iframe` match the height of the child. ([This](https://github.com/derilinx/ckanext-pdfview/commit/36081910d5bc38dcfbe82ac596c34c3b3be36107) does the inverse, and modifies the child height to match the parent's minimum.)

Companion PR to azavea/opendataphilly-ckan#83.