### PR TITLE
Fix broken context references on dataset "Topics" tab

### DIFF
--- a/ckanext/odp_theme/templates/package/group_list.html
+++ b/ckanext/odp_theme/templates/package/group_list.html
@@ -4,10 +4,10 @@
 {% block primary_content_inner %}
   <h2 class="hide-heading">{{ _('Topics') }}</h2>
 
-  {% if group_dropdown %}
+  {% if c.group_dropdown %}
     <form class="add-to-group" method="post">
       <select id="field-add_group" name="group_added" data-module="autocomplete">
-        {% for option in group_dropdown %}
+        {% for option in c.group_dropdown %}
           <option value="{{ option[0] }}"> {{ option[1] }}</option>
         {% endfor %}
       </select>
@@ -15,9 +15,9 @@
     </form>
   {% endif %}
 
-  {% if pkg_dict.groups %}
+  {% if c.pkg_dict.groups %}
     <form method="post">
-      {% snippet 'group/snippets/group_list.html', groups=pkg_dict.groups %}
+      {% snippet 'group/snippets/group_list.html', groups=c.pkg_dict.groups %}
     </form>
   {% else %}
     <p class="empty">{{ _('There are no topics associated with this dataset') }}</p>


### PR DESCRIPTION
This was a case where the [current `master` version](https://github.com/ckan/ckan/blob/1e65b0644e46ba02d88c18c35c1bfcd2dcfdf2f3/ckan/templates/package/group_list.html) is different from [CKAN 2.8.1](https://github.com/ckan/ckan/blob/ckan-2.8.1/ckan/templates/package/group_list.html) and I mistakenly updated our overrides based on the master version.

I did some searching in the code to try to see if there are other cases of this type of error hiding out, and I think there aren't.

![image](https://user-images.githubusercontent.com/6598836/46483811-85615280-c7c6-11e8-8e11-deb511c7f8b0.png)

#### Testing instructions

Given a working development instance, just update your checkout of `ckanext-odp_theme`, restart apache2, and click through to the "Topics" tab on any dataset to see it work.  Without a working dev instance, I'm not sure it's worth all the trouble of spinning up and migrating one just to see this 8-character change in action...

Resolves https://github.com/azavea/opendataphilly-ckan/issues/88