### PR TITLE
Remove 'Metadata last updated' and 'Last updated' on datasets

### DIFF
--- a/ckanext/odp_theme/templates/package/resource_read.html
+++ b/ckanext/odp_theme/templates/package/resource_read.html
@@ -11,10 +11,6 @@
     </thead>
     <tbody>
       <tr>
-        <th scope="row">{{ _('Data last updated') }}</th>
-        <td>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.created) or _('unknown') }}</td>
-      </tr>
-      <tr>
         <th scope="row">{{ _('Metadata last updated') }}</th>
         <td>{{ h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
       </tr>

--- a/ckanext/odp_theme/templates/package/resource_read.html
+++ b/ckanext/odp_theme/templates/package/resource_read.html
@@ -11,10 +11,6 @@
     </thead>
     <tbody>
       <tr>
-        <th scope="row">{{ _('Metadata last updated') }}</th>
-        <td>{{ h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</td>
-      </tr>
-      <tr>
         <th scope="row">{{ _('Created') }}</th>
         <td>{{ h.render_datetime(res.created) or _('unknown') }}</td>
       </tr>

--- a/ckanext/odp_theme/templates/package/snippets/additional_info.html
+++ b/ckanext/odp_theme/templates/package/snippets/additional_info.html
@@ -50,14 +50,6 @@
     <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
   </tr>
   {% endif %}
-  {% if pkg_dict.metadata_modified %}
-  <tr>
-    <th scope="row" class="dataset-label">{{ _("Metadata last updated") }}</th>
-    <td class="dataset-details">
-        {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
-    </td>
-  </tr>
-  {% endif %}
   {% if pkg_dict.metadata_created %}
   <tr>
     <th scope="row" class="dataset-label">{{ _("Created") }}</th>

--- a/ckanext/odp_theme/templates/package/snippets/additional_info.html
+++ b/ckanext/odp_theme/templates/package/snippets/additional_info.html
@@ -1,0 +1,81 @@
+{% ckan_extends %}
+{# This whole block, which is basically the whole file, is overridden just to change
+   the label on the 'pkg_dict.metadata_modified' row. #}
+{% block package_additional_info %}
+  {% if pkg_dict.url %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _('Source') }}</th>
+    {% if h.is_url(pkg_dict.url) %}
+      <td class="dataset-details" property="foaf:homepage">{{ h.link_to(pkg_dict.url, pkg_dict.url, rel='foaf:homepage', target='_blank') }}</td>
+    {% else %}
+      <td class="dataset-details" property="foaf:homepage">{{ pkg_dict.url }}</td>
+    {% endif %}
+  </tr>
+  {% endif %}
+
+  {% if pkg_dict.author_email %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+    <td class="dataset-details" property="dc:creator">{{ h.mail_to(email_address=pkg_dict.author_email, name=pkg_dict.author) }}</td>
+  </tr>
+  {% elif pkg_dict.author %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _("Author") }}</th>
+    <td class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</td>
+  </tr>
+  {% endif %}
+
+  {% if pkg_dict.maintainer_email %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+    <td class="dataset-details" property="dc:contributor">{{ h.mail_to(email_address=pkg_dict.maintainer_email, name=pkg_dict.maintainer) }}</td>
+  </tr>
+  {% elif pkg_dict.maintainer %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _('Maintainer') }}</th>
+    <td class="dataset-details" property="dc:contributor">{{ pkg_dict.maintainer }}</td>
+  </tr>
+  {% endif %}
+
+  {% if pkg_dict.version %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _("Version") }}</th>
+    <td class="dataset-details">{{ pkg_dict.version }}</td>
+  </tr>
+  {% endif %}
+
+  {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _("State") }}</th>
+    <td class="dataset-details">{{ _(pkg_dict.state) }}</td>
+  </tr>
+  {% endif %}
+  {% if pkg_dict.metadata_modified %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _("Metadata last updated") }}</th>
+    <td class="dataset-details">
+        {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_modified %}
+    </td>
+  </tr>
+  {% endif %}
+  {% if pkg_dict.metadata_created %}
+  <tr>
+    <th scope="row" class="dataset-label">{{ _("Created") }}</th>
+
+    <td class="dataset-details">
+        {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=pkg_dict.metadata_created %}
+    </td>
+  </tr>
+  {% endif %}
+
+  {% block extras scoped %}
+    {% for extra in h.sorted_extras(pkg_dict.extras) %}
+    {% set key, value = extra %}
+    <tr rel="dc:relation" resource="_:extra{{ i }}">
+      <th scope="row" class="dataset-label" property="rdfs:label">{{ _(key) }}</th>
+      <td class="dataset-details" property="rdf:value">{{ value }}</td>
+    </tr>
+    {% endfor %}
+  {% endblock %}
+
+{% endblock %}


### PR DESCRIPTION
## Overview

Since many or most of the resource entities on ODP datasets point to external resources that could change at any time, the `last_modified` property on resources doesn't reflect reality, and displaying it as "Last updated" will tend to make things look out-of-date when they actually aren't. So this removes "Last updated" on the Resource view ~and changes "Last Updated" on the Dataset view (which is based on the `metadata_modified` property) to say "Metadata last updated", to avoid confusion.~

UPDATE: It also removes the "Metadata last updated" fields.

### Demo

#### New screenshots
On the dataset page (bottom of https://www.opendataphilly.org/dataset/opa-property-assessments):
![image](https://user-images.githubusercontent.com/6598836/48157302-39aa3900-e29d-11e8-95f0-2986c0899da2.png)

On the resource page (https://www.opendataphilly.org/dataset/opa-property-assessments/resource/6d9ce508-b770-402d-ad84-94b36b0c7550):
![image](https://user-images.githubusercontent.com/6598836/48157275-2dbe7700-e29d-11e8-83c3-0001fee45648.png)

#### Old screenshots
On the dataset page (bottom of https://www.opendataphilly.org/dataset/opa-property-assessments):
![image](https://user-images.githubusercontent.com/6598836/47857358-c9447900-ddbf-11e8-842e-bc3cb966a3fe.png)

On the resource page (https://www.opendataphilly.org/dataset/opa-property-assessments/resource/6d9ce508-b770-402d-ad84-94b36b0c7550):
![image](https://user-images.githubusercontent.com/6598836/47857387-d95c5880-ddbf-11e8-9061-868680c6cbd4.png)

### Notes

- This required adding `package/snippets/additional_info.html` to override the label.  Unfortunately I had to copy almost the whole file to do the one change.  So it goes.
- ~If we decide we actually want to remove the "Metadata last updated" rows, that's easy now that we have both templates overridden.~ Yup, it was easy.

## Testing Instructions

Check out this branch in your `ckanext-odp_theme` checkout and spin up your instance.  It should look like the screenshots above.

Resolves https://github.com/azavea/urban-apps/issues/122
