### PR TITLE
Add robots.txt template to block web crawlers

### DIFF
--- a/ckanext/odp_theme/templates/robots.txt
+++ b/ckanext/odp_theme/templates/robots.txt
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block additional_user_agents %}
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+{% endblock %}


### PR DESCRIPTION
# Overview

In https://github.com/azavea/opendataphilly-ckan/pull/95, we blocked web crawlers by editing the Nginx configuration for the deployment directly and blocking requests from certain user agents. Block these user agents in CKAN's `robots.txt` file as well, which is the canonical way to block web crawlers.

Connects https://github.com/azavea/opendataphilly-ckan/issues/92.

## Notes

- I wasn't actually able to get this app fully provisioned on my machine to test this change. I persisted through some esoteric VM mount issues but then hit a wall when Postgres wouldn't bind to port `5432`. Since the change is so simple, I decided to just open the PR and push off VM debugging for a later date.

## Testing instructions

1. Pull in this branch next to an instance of https://github.com/azavea/opendataphilly-ckan
2. Reprovision `opendataphilly-ckan` and get it running on `localhost:8025`
3. Visit `localhost:8025/robots.txt` and confirm that you see the following rules:

```
User-agent: SemrushBot
Disallow: /

User-agent: MJ12bot
Disallow: /

User-agent: AhrefsBot
Disallow: /

User-agent: BLEXBot
Disallow: /
```