### PR TITLE
Restore activity stream functions for 'related' activities

### DIFF
--- a/ckanext/odp_theme/plugin.py
+++ b/ckanext/odp_theme/plugin.py
@@ -37,17 +37,27 @@ def ckan_site_url():
     return config.get('ckan.site_url', '').rstrip('/')
 
 
-# monkeypatch activity streams
+# monkeypatch activity streams to rename 'group' to 'topic'
 activity_streams['changed group'] = (
     lambda c, a: tk._("{actor} updated the topic {group}")
 )
-
 activity_streams['deleted group'] = (
     lambda c, a: tk._("{actor} deleted the topic {group}")
 )
-
 activity_streams['new group'] = (
     lambda c, a: tk._("{actor} created the topic {group}")
+)
+
+# Add back activity types removed in the 'related'->'showcase' upgrade.
+# They'll be generic, but at least they won't crash.
+activity_streams['changed related item'] = (
+    lambda c, a: tk._("{actor} updated a related item.")
+)
+activity_streams['deleted related item'] = (
+    lambda c, a: tk._("{actor} deleted a related item.")
+)
+activity_streams['new related item'] = (
+    lambda c, a: tk._("{actor} created a related item.")
 )
 
 


### PR DESCRIPTION
## Overview

With the change from 'related' to 'showcase' (see https://github.com/azavea/opendataphilly-ckan/pull/86 and https://github.com/azavea/ckanext-odp_theme/pull/60), the functions for translating the related-item activity stream entries went away, but the data didn't. And it turns out it's a crash to have an unimplemented activity type in your stream.

![image](https://user-images.githubusercontent.com/6598836/55111055-dedc7700-50af-11e9-8563-91eec846c0c6.png)


It seems better to restore them (albeit diminished, since they won't name or link to the actual related item) than to erase them from history. And having extra, potentially-unused activity type functions doesn't hurt anything. So this adds functions to handle those activity types.

### Demo

![image](https://user-images.githubusercontent.com/6598836/55111092-f3b90a80-50af-11e9-9e9a-53290226b878.png)

## Testing Instructions

- You'll need to have a database import.  An old one should work fine.  See https://github.com/azavea/opendataphilly-ckan#importing-into-development for import instructions if necessary.
- Find a user with "related item"-related activity:
  ```
  vagrant ssh database<<EOF
  export PGPASSWORD=ckan_default
  psql -U ckan_default -h 127.0.0.1 -d ckan_default -c "SELECT DISTINCT name FROM public.user
    JOIN activity ON user_id=public.user.id WHERE activity_type LIKE '%related%';"
  EOF
  ```
- Go to the useractivity page for one of those users, at http://localhost:8025/user/activity/USERNAME.  It should work, and you should see entries about "related item" activity.
- To test the dashboard, reset the password of one of those users (`vagrant ssh app -c 'sudo ckan user setpass USERNAME'`) and log in as them.  The default tab on the dashboard, "News feed", should now show the same activity list (rather than crashing).